### PR TITLE
Use concatenated DataTables scripts/stylesheets...

### DIFF
--- a/_includes/preconnect.html
+++ b/_includes/preconnect.html
@@ -20,25 +20,8 @@
 {%- endif -%}
 {%- if page.include_datatables == true -%}
 <!-- preload DataTables styles and scripts -->
-{% comment %}
-<link rel="preload" as="style" href="https://cdn.datatables.net/1.10.18/css/dataTables.bootstrap4.min.css">
-<link rel="preload" as="style" href="https://cdn.datatables.net/responsive/2.2.2/css/responsive.bootstrap4.min.css">
-<link rel="preload" as="script" href="https://cdn.datatables.net/1.10.18/js/jquery.dataTables.min.js">
-<link rel="preload" as="script" href="https://cdn.datatables.net/1.10.18/js/dataTables.bootstrap4.min.js">
-<link rel="preload" as="script" href="https://cdn.datatables.net/responsive/2.2.2/js/dataTables.responsive.min.js">
-{% endcomment %}
-<link rel="preload" as="style" href="https://cdn.datatables.net/1.13.10/css/dataTables.bootstrap4.min.css">
-{% if page.url contains '/roster/' %}<link rel="preload" as="style" href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.bootstrap4.min.css">{% endif %}
-<link rel="preload" as="style" href="https://cdn.datatables.net/responsive/2.5.0/css/responsive.bootstrap4.min.css">
-<link rel="preload" as="script" href="https://cdn.datatables.net/1.13.10/js/jquery.dataTables.min.js">
-<link rel="preload" as="script" href="https://cdn.datatables.net/1.13.10/js/dataTables.bootstrap4.min.js">
-{% if page.url contains '/roster/' %}
-<link rel="preload" as="script" href="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js">
-<link rel="preload" as="script" href="https://cdn.datatables.net/buttons/2.4.2/js/buttons.bootstrap4.min.js">
-<link rel="preload" as="script" href="https://cdn.datatables.net/buttons/2.4.2/js/buttons.print.min.js">
-{% endif %}
-<link rel="preload" as="script" href="https://cdn.datatables.net/responsive/2.5.0/js/dataTables.responsive.min.js">
-<link rel="preload" as="script" href="https://cdn.datatables.net/responsive/2.5.0/js/responsive.bootstrap4.js">
+<link rel="preload" as="style" href="https://cdn.datatables.net/v/bs4/dt-1.13.10/b-2.4.2/b-print-2.4.2/r-2.5.0/datatables.min.css">
+<link rel="preload" as="script" href="https://cdn.datatables.net/v/bs4/dt-1.13.10/b-2.4.2/b-print-2.4.2/r-2.5.0/datatables.min.js">
 {%- endif -%}
 {%- if site.theme_config != true -%}
 <!-- preload the main custom stylesheet -->

--- a/_includes/script/table-scripts.html
+++ b/_includes/script/table-scripts.html
@@ -1,17 +1,2 @@
-{% comment %}  
-<!-- dataTable's JS (v1.10.18 for use w/ bootstrap4 theme) -->
-<script src="https://cdn.datatables.net/1.10.18/js/jquery.dataTables.min.js"></script>
-<!-- dataTable's Bootstrap4 theme's JS -->
-<script src="https://cdn.datatables.net/1.10.18/js/dataTables.bootstrap4.min.js"></script>
-<!-- dataTable's JS for "Responsive" extension -->
-<script src="https://cdn.datatables.net/responsive/2.2.2/js/dataTables.responsive.min.js"></script>
-{% endcomment %}
-<script src="https://cdn.datatables.net/1.13.10/js/jquery.dataTables.min.js"></script>
-<script src="https://cdn.datatables.net/1.13.10/js/dataTables.bootstrap4.min.js"></script>
-{% if page.url contains '/roster/' %}
-<script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
-<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.bootstrap4.min.js"></script>
-<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.print.min.js"></script>
-{% endif %}
-<script src="https://cdn.datatables.net/responsive/2.5.0/js/dataTables.responsive.min.js"></script>
-<script src="https://cdn.datatables.net/responsive/2.5.0/js/responsive.bootstrap4.js"></script>
+<!-- DataTables minified and concatenated JS (with extensions): DataTables + BS4 + Buttons + Print + Responsive -->
+<script src="https://cdn.datatables.net/v/bs4/dt-1.13.10/b-2.4.2/b-print-2.4.2/r-2.5.0/datatables.min.js"></script>

--- a/_includes/styles/datatables.html
+++ b/_includes/styles/datatables.html
@@ -1,10 +1,2 @@
-<!-- dataTables stylesheets -->
-{% comment %}  
-<!-- dataTables Bootstrap4 themed stylesheet -->
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.18/css/dataTables.bootstrap4.min.css"/>
-<!-- dataTables "Responsive" extension stylesheet for bootstrap4 theme -->
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/responsive/2.2.2/css/responsive.bootstrap4.min.css"/>
-{% endcomment %}
-<link href="https://cdn.datatables.net/1.13.10/css/dataTables.bootstrap4.min.css" rel="stylesheet">
-{% if page.url contains '/roster/' %}<link href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.bootstrap4.min.css" rel="stylesheet">{% endif %}
-<link href="https://cdn.datatables.net/responsive/2.5.0/css/responsive.bootstrap4.min.css" rel="stylesheet">
+<!-- DataTables minified and concatenated stylesheets (with extensions): DataTables + BS4 + Buttons + Print + Responsive -->
+<link href="https://cdn.datatables.net/v/bs4/dt-1.13.10/b-2.4.2/b-print-2.4.2/r-2.5.0/datatables.min.css" rel="stylesheet">

--- a/baseball/stats.html
+++ b/baseball/stats.html
@@ -7,7 +7,7 @@ base: baseball
 sport_sub_nav: true
 sub-nav_hidden: true
 body_class: page ## <landing|page>
-include_datatables: true
+include_datatables: false
 include_gapi: true
 include_sub-nav: true
 include_poppers: true

--- a/mens-basketball/stats.html
+++ b/mens-basketball/stats.html
@@ -7,7 +7,7 @@ base: mens-basketball
 sport_sub_nav: true
 sub-nav_hidden: true
 body_class: page ## <landing|page>
-include_datatables: true
+include_datatables: false
 include_gapi: true
 include_sub-nav: true
 include_poppers: true

--- a/soccer/stats.html
+++ b/soccer/stats.html
@@ -7,7 +7,7 @@ base: soccer
 sport_sub_nav: true
 sub-nav_hidden: true
 body_class: page ## <landing|page>
-include_datatables: true
+include_datatables: false
 include_gapi: true
 include_sub-nav: true
 include_poppers: true

--- a/softball/stats.html
+++ b/softball/stats.html
@@ -5,7 +5,7 @@ title: Softball Stats
 description: "Kankakee Community College Cavaliers Softball statistics."
 base: softball
 body_class: page ## <landing|page>
-include_datatables: true
+include_datatables: false
 include_gapi: true
 include_sub-nav: true
 include_poppers: true

--- a/volleyball/stats.html
+++ b/volleyball/stats.html
@@ -7,7 +7,7 @@ base: volleyball
 sport_sub_nav: true
 sub-nav_hidden: true
 body_class: page ## <landing|page>
-include_datatables: true
+include_datatables: false
 include_gapi: true
 include_sub-nav: true
 include_poppers: true

--- a/womens-basketball/stats.html
+++ b/womens-basketball/stats.html
@@ -7,7 +7,7 @@ base: womens-basketball
 sport_sub_nav: true
 sub-nav_hidden: true
 body_class: page ## <landing|page>
-include_datatables: true
+include_datatables: false
 include_gapi: true
 include_sub-nav: true
 include_poppers: true

--- a/womens-soccer/stats.html
+++ b/womens-soccer/stats.html
@@ -5,7 +5,7 @@ title: Women's Soccer Stats
 description: "Kankakee Community College Cavaliers Women's Soccer statistics."
 base: womens-soccer
 body_class: page ## <landing|page>
-include_datatables: true
+include_datatables: false
 include_gapi: true
 include_sub-nav: true
 include_poppers: true


### PR DESCRIPTION
* Switch to concatenated stylesheets and scripts for faster loading of DataTables libraries.
* Remove DataTables from stats pages (stats pages do not use DataTables).